### PR TITLE
Fix the broken build #26

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "gulp-karma": "^0.0.4",
     "gulp-ng-constant": "^0.1.0",
     "gulp-help": "^0.1.0",
-    "gulp-gh-pages": "~0.3.2",
+    "gulp-gh-pages": "0.1.4",
     "gulp-inject": "^0.4.1",
     "gulp-nodemon": "^1.0.2",
     "gulp-istanbul-enforcer": "^1.0.2",


### PR DESCRIPTION
There some issue with latest version that doesn't publish to gh-pages. We should use version `0.1.4` that works fine.
