### PR TITLE
Fix the build, add new pre-commit hook

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -116,7 +116,7 @@ function run {
         git push origin $TAG_NAME
 
         # Publish to GitHub gs-pages branch
-        gulp gh-pages
+#        gulp gh-pages
 
         deploy_to_heroku "Deploy release v$TAG_NAME"
 
@@ -150,7 +150,7 @@ function run {
         fi
 
         # Publish to GitHub gs-pages branch
-        gulp gh-pages
+#        gulp gh-pages
 
         deploy_to_heroku "Deploy prerelease v$NEW_VERSION"
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -562,7 +562,7 @@ gulp.task('test:unit', 'Run unit tests', function () {
             browsers: [BROWSERS],
             env: ENV
         }))
-//        .pipe(coverageEnforcer(options))
+        .pipe(coverageEnforcer(options))
         .on('error', function (error) {
             gutil.log(COLORS.red('Error: Unit test failed ' + error));
             return process.exit(1);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "booking"
   ],
   "dependencies": {
+    "pre-commit": "0.0.9",
     "express": "^4.1.0",
     "morgan": "^1.0.0",
     "body-parser": "^1.0.2",


### PR DESCRIPTION
I have commented out the code that broke the build (there is still issue when we are publishing tests and artifacts to gh-pages branch - I need to fix that in the future).

I have added new pre-commit plugin.

I have notice that we are not running test properly.. in [karma config file](https://github.com/cam-technologies/time-booker/blob/master/client/test/config/karma.conf.js#L48) we run tests only against 'client/src/app/app.js' instead of 'client/src/*_/_.js'.. this mean our coverage is incorrect so we should have look on this in the future
