### PR TITLE
PR: moving migrations and adding gulp migration command fixes #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Note you should run these commands as admin.
     ```
 * [Install Migrate](https://github.com/visionmedia/node-migrate) as global module. 
     ```bash
-    $ npm install -g migrate
+    $ gulp migrate
     ```
 
 ### App
@@ -199,6 +199,7 @@ The main gulp tasks are descriptive more in `development`, `test`, `build` and `
 | `gulp bump` | will increment version number in [`package.json`](package.json) and [`bower.json`](bower.json)|
 | `gulp changelog` | will generate changelog in [`CHANGELOG.md`](CHANGELOG.md) |
 | `gulp release` | will release and push [`package.json`](package.json) and [`CHANGELOG.md`](CHANGELOG.md) to GitHub repo |
+| `gulp migrate` | will run the data base migrations |
 
 ## Development
 Whenever you're working on project, start with:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -688,3 +688,10 @@ gulp.task('compass', function() {
         }))
         .pipe(gulp.dest('client/src/assets/styles/'));
 });
+
+/**
+ * Run data base migrations.
+ */
+gulp.task('migrate', shell.task([
+    'migrate --chdir server/src/config/db/'
+]));

--- a/migrations/.migrate
+++ b/migrations/.migrate
@@ -1,1 +1,0 @@
-{"migrations":[{"title":"migrations/001-add-users.js"}],"path":"migrations/.migrate","pos":0,"_events":{}}

--- a/server/src/config/db/migrations/.migrate
+++ b/server/src/config/db/migrations/.migrate
@@ -1,0 +1,1 @@
+{"migrations":[{"title":"migrations/001-add-users.js"}],"path":"migrations/.migrate","pos":1,"_events":{}}

--- a/server/src/config/db/migrations/001-add-users.js
+++ b/server/src/config/db/migrations/001-add-users.js
@@ -4,7 +4,7 @@ exports.up = function (next) {
     migrationHelper.database.once('open', function() {
         migrationHelper.addNewUser('Chris Laughlin', 'contact@christopherlaughlin.co.uk', 'Chris1234');
         migrationHelper.addNewUser('Martin Micunda', 'martinmicunda@hotmail.com', 'Martin1234');
-        migrationHelper.addNewUser('Andy McDowell', 'andrew.g.mcdowell@gmail.com', 'Andy1234', next());
+        migrationHelper.addNewUser('Andy McDowell', 'andrew.g.mcdowell@gmail.com', 'Andy1234', next);
         });
 };
 
@@ -12,9 +12,8 @@ exports.down = function (next) {
     migrationHelper.database.once('open', function() {
         migrationHelper.removeUser('contact@christopherlaughlin.co.uk');
         migrationHelper.removeUser('martinmicunda@hotmail.com');
-        migrationHelper.removeUser('andrew.g.mcdowell@gmail.com');
+        migrationHelper.removeUser('andrew.g.mcdowell@gmail.com', next);
         });
-    next();
 };
 
 

--- a/server/src/config/db/migrations/001-add-users.js
+++ b/server/src/config/db/migrations/001-add-users.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var migrationHelper = require('./migration-helper');
 
 exports.up = function (next) {

--- a/server/src/config/db/migrations/migration-helper.js
+++ b/server/src/config/db/migrations/migration-helper.js
@@ -1,3 +1,4 @@
+'use strict';
 // Imports
 var config  = require('../../config');
 var mongoose = require('mongoose');
@@ -20,7 +21,7 @@ exports.addNewUser = function(name, email, password, next) {
 
     user.save(function (err) {
         if (!err) {
-            console.info("User created: " + user);
+            console.info('User created: ' + user);
         } else {
             console.error(err);
         }

--- a/server/src/config/db/migrations/migration-helper.js
+++ b/server/src/config/db/migrations/migration-helper.js
@@ -1,7 +1,7 @@
 // Imports
-var config  = require('../server/src/config/config');
+var config  = require('../../config');
 var mongoose = require('mongoose');
-var User = require('../server/src/models/user');
+var User = require('../../../models/user');
 
 //Processing
 mongoose.connect(config.get('database'));
@@ -30,8 +30,11 @@ exports.addNewUser = function(name, email, password, next) {
     }
 };
 
-exports.removeUser = function(email) {
+exports.removeUser = function(email, next) {
     User.findOne({email:email}, function(err, doc) {
         doc.remove();
+        if (next){
+            next();
+        }
     });
 };


### PR DESCRIPTION
To clear up migrations, these for now will be used for seeding data into the development data base, we can also use it for applying changes to existing data in production e.g. if we need to add or remove attributes on a schema. Currently they only run on development *_pending production config *_\* when we start to use them for production we can flag changes that are dev only by checking the env. Any questions? we can chat on here or on hipchat. Think of them as the same as what we had on RSQE with the 'gradle applyDBupdates' 
